### PR TITLE
A bug affecting the calculation of n-type sample

### DIFF
--- a/analyser/analysis/analysis.py
+++ b/analyser/analysis/analysis.py
@@ -23,7 +23,6 @@ class Data():
 
     Derivitive = 'Finite Difference'
     Analysis = 'Generalised'
-    Type = 'p'
     CropStart = 0
     CropEnd = 100
     BackgroundSubtraction = 0.95

--- a/analyser/analysis/analysis.py
+++ b/analyser/analysis/analysis.py
@@ -41,11 +41,11 @@ class Data():
         pass
 
     def BackgrounConcentration(self):
-        if (self.Type == 'p'):
+        if (self.Wafer['Type'] == 'p'):
             self.nh0 = self.Wafer['Doping']
             self.ne0 = self.ni**2 / self.Wafer['Doping']
 
-        elif(self.Type == 'n'):
+        elif(self.Wafer['Type'] == 'n'):
             self.ne0 = self.Wafer['Doping']
             self.nh0 = self.ni**2 / self.Wafer['Doping']
         else:


### PR DESCRIPTION
self.Type is fixed to be 'p', self.Wafer['Type'] should be used instead